### PR TITLE
Bugfix & Transparent BG option

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -24,4 +24,5 @@
 			"type":"bool",
 			"default":false
 		}
+	}
 }

--- a/mod.json
+++ b/mod.json
@@ -16,5 +16,12 @@
 			"resources/*.png"
 		]
 	},
-	"repository": "https://github.com/geode-sdk/textureldr"
+	"repository": "https://github.com/geode-sdk/textureldr",
+	"settings":{
+		"transparent":{
+			"name":"Transparent Background",
+			"description":"Remove the blue blender of the Pack Select Menu's background.",
+			"type":"bool",
+			"default":false
+		}
 }

--- a/src/PackManager.cpp
+++ b/src/PackManager.cpp
@@ -112,10 +112,10 @@ void PackManager::updateAppliedPacks() {
 }
 
 void PackManager::applyPacks(CreateLayerFunc func) {
-    savePacks();
     this->updateAppliedPacks();
     // TODO: find this function
     // FMODAudioEngine::sharedEngine()->stopAllMusic();
+    loadPacks();    
     reloadTextures(std::move(func));
 }
 

--- a/src/PackManager.cpp
+++ b/src/PackManager.cpp
@@ -112,6 +112,7 @@ void PackManager::updateAppliedPacks() {
 }
 
 void PackManager::applyPacks(CreateLayerFunc func) {
+    savePacks();
     this->updateAppliedPacks();
     // TODO: find this function
     // FMODAudioEngine::sharedEngine()->stopAllMusic();

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,7 +22,8 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
-    background->setColor({255, 255, 255});
+    if (Mod->get()->getSettingValue<bool>("transparent")){
+        background->setColor({255, 255, 255});}
     this->addChild(background);
 
     auto winSize = CCDirector::get()->getWinSize();

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,7 +22,7 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
-    if (Mod->get()->getSettingValue<bool>("transparent")){
+    if (Mod::get()->getSettingValue<bool>("transparent")){
         background->setColor({255, 255, 255});}
     this->addChild(background);
 

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,6 +22,7 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
+    background->setColor({255, 255, 255})
     this->addChild(background);
 
     auto winSize = CCDirector::get()->getWinSize();

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,7 +22,7 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
-    background->setColor({255, 255, 255})
+    background->setColor({255, 255, 255});
     this->addChild(background);
 
     auto winSize = CCDirector::get()->getWinSize();


### PR DESCRIPTION
~~Ignore the 8 commit lines plz I'm 1st time to fork and pull req sry~~
## Bugfix
Fix the bug when the user drags a pack from applied to available and click that Apply Button, the pack is still taking effects until game restart.  
So I just adds a loadPacks step to *PackManager::applyPacks*  
## Transparent BG option
Adds transparent BG to PackSelectLayer cuz why not