### PR TITLE
Bugfix and Transparent BG option

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -17,12 +17,12 @@
 		]
 	},
 	"repository": "https://github.com/geode-sdk/textureldr",
-	"settings":{
-		"transparent":{
-			"name":"Transparent Background",
-			"description":"Remove the blue blender of the Pack Select Menu's background.",
-			"type":"bool",
-			"default":false
+	"settings": {
+		"transparent": {
+			"name": "Transparent Background",
+			"description": "Removes the blue tint on the Pack Select layer",
+			"type": "bool",
+			"default": false
 		}
 	}
 }

--- a/mod.json
+++ b/mod.json
@@ -16,5 +16,13 @@
 			"resources/*.png"
 		]
 	},
-	"repository": "https://github.com/geode-sdk/textureldr"
+	"repository": "https://github.com/geode-sdk/textureldr",
+	"settings":{
+		"transparent":{
+			"name":"Transparent Background",
+			"description":"Remove the blue blender of the Pack Select Menu's background.",
+			"type":"bool",
+			"default":false
+		}
+	}
 }

--- a/src/PackManager.cpp
+++ b/src/PackManager.cpp
@@ -96,6 +96,7 @@ size_t PackManager::loadPacks() {
     m_available = found;
 
     this->updateAppliedPacks();
+
     log::info("Loaded {} packs", loaded);
 
     return loaded;

--- a/src/PackManager.cpp
+++ b/src/PackManager.cpp
@@ -25,13 +25,16 @@ std::vector<std::shared_ptr<Pack>> PackManager::getAppliedPacks() const {
 
 void PackManager::movePackToIdx(const std::shared_ptr<Pack>& pack, PackListType to, size_t index) {
     auto& destination = to == PackListType::Applied ? m_applied : m_available;
-    auto& from = to != PackListType::Applied ? m_applied : m_available;
-
-    ranges::remove(from, pack);
-    if (index < destination.size()) {
-        destination.insert(destination.begin() + static_cast<ptrdiff_t>(index), pack);
+    if (ranges::contains(destination, pack)) {
+        ranges::move(destination, pack, index);
     } else {
-        destination.push_back(pack);
+        auto& from = to != PackListType::Applied ? m_applied : m_available;
+        ranges::remove(from, pack);
+        if (index < destination.size()) {
+            destination.insert(destination.begin() + static_cast<ptrdiff_t>(index), pack);
+        } else {
+            destination.push_back(pack);
+        }
     }
 }
 

--- a/src/PackManager.cpp
+++ b/src/PackManager.cpp
@@ -119,7 +119,7 @@ void PackManager::updateAppliedPacks() {
 }
 
 void PackManager::applyPacks(CreateLayerFunc func) {
-    updateAppliedPacks();
+    this->updateAppliedPacks();
     // TODO: find this function
     // FMODAudioEngine::sharedEngine()->stopAllMusic();
     reloadTextures(std::move(func));

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,8 +22,9 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
-    if (Mod::get()->getSettingValue<bool>("transparent")){
-        background->setColor({255, 255, 255});}
+    if (Mod::get()->getSettingValue<bool>("transparent")) {
+        background->setColor({255, 255, 255});
+    }
     this->addChild(background);
 
     auto winSize = CCDirector::get()->getWinSize();

--- a/src/PackSelectLayer.cpp
+++ b/src/PackSelectLayer.cpp
@@ -22,6 +22,8 @@ bool PackSelectLayer::init() {
 
     auto background = createLayerBG();
     background->setID("background");
+    if (Mod::get()->getSettingValue<bool>("transparent")){
+        background->setColor({255, 255, 255});}
     this->addChild(background);
 
     auto winSize = CCDirector::get()->getWinSize();


### PR DESCRIPTION
## Bugfix
#### Bug desc
Texture Loader has a bug that, when a user drags a pack from applied to available and click the apply button, the pack still keeps taking effects until game restart.
#### Reason
The texture files contained in the unapplied pack have been merged by that pack on game start, and will not return to raw textures when the user just click the apply button.
#### Solution
This pull adds raw texture directory as the lowest priority applied pack to PackManager::updateAppliedPacks, so to click the apply button will reload raw textures.  
I'm not sure whether this will result in the raw textures multiply loaded on game start or not (though this affects nothing in visual), but for now i have no idea :(
## Transparent BG option
For background customizer, it removes the blue blender from the PackSelectLayer background cuz why not
Regarding official background file looks weird in white there, it's optional and default to off.