### PR TITLE
Fix API header inclusion

### DIFF
--- a/include/TextureLoader.hpp
+++ b/include/TextureLoader.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Geode/loader/Dispatch.hpp>
+#include <Geode/loader/Loader.hpp>
+#include <Geode/utils/VersionInfo.hpp>
 
 #include <filesystem>
 #include <vector>


### PR DESCRIPTION
For people who disable Geode's pre-compiled headers